### PR TITLE
Set --host flag for autotools to support cross compilation

### DIFF
--- a/webrtc-audio-processing-sys/README.md
+++ b/webrtc-audio-processing-sys/README.md
@@ -1,4 +1,5 @@
 # webrtc-audio-processing-sys
+
 [![Crates.io](https://img.shields.io/crates/v/webrtc-audio-processing-sys.svg)](https://crates.io/crates/webrtc-audio-processing-sys)
 [![Docs.rs](https://docs.rs/webrtc-audio-processing-sys/badge.svg)](https://docs.rs/webrtc-audio-processing-sys)
 [![Build Status](https://travis-ci.org/tonarino/webrtc-audio-processing.svg?branch=master)](https://travis-ci.org/tonarino/webrtc-audio-processing)
@@ -21,11 +22,20 @@ sudo apt install webrtc-audio-processing-dev # Ubuntu/Debian
 sudo pacman -S webrtc-audio-processing # Arch
 ```
 
+### Cross compilation
+
+When cross-compiling make sure you have the corresponding rust toolchain installed
+with `rustup target add <target>` and then run
+
+```sh
+PKG_CONFIG_SYSROOT_DIR=/ cargo build --target <target>
+```
+
 ### Static linking
 
 Static linking can be enabled with the `bundled` feature flag.
 
 The following tools are needed in order to use the `bundled` feature flag:
 
-* libtool (`$ sudo apt install libtool`)
-* autotools (`$ sudo apt install autotools-dev`)
+- libtool (`$ sudo apt install libtool`)
+- autotools (`$ sudo apt install autotools-dev`)

--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -63,6 +63,16 @@ mod webrtc {
         Ok((include_path, lib_path))
     }
 
+    fn get_target() -> String {
+        let target = std::env::var("TARGET").unwrap();
+        let mut target_tuple = target.split("-").collect::<Vec<_>>();
+        // Remove the vendor component.
+        target_tuple.remove(1);
+
+        assert_eq!(3, target_tuple.len());
+        target_tuple.join("-")
+    }
+
     fn copy_source_to_out_dir() -> Result<PathBuf, Error> {
         use fs_extra::dir::CopyOptions;
 
@@ -93,6 +103,7 @@ mod webrtc {
             .cxxflag("-fPIC")
             .disable_shared()
             .enable_static()
+            .host(&get_target())
             .build();
 
         Ok(())


### PR DESCRIPTION
https://docs.rs/autotools/0.2.1/autotools/struct.Config.html#method.host
It's set automatically, but based on the compilation host. We want the target architecture to be set for `--host` flag.