### PR TITLE
Add a warning that provides more context when a bundled build from source fails

### DIFF
--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -55,6 +55,7 @@ mod webrtc {
 #[cfg(feature = "bundled")]
 mod webrtc {
     use super::*;
+
     const BUNDLED_SOURCE_PATH: &str = "./webrtc-audio-processing";
 
     pub(super) fn get_build_paths() -> Result<(PathBuf, PathBuf), Error> {
@@ -65,6 +66,13 @@ mod webrtc {
 
     fn copy_source_to_out_dir() -> Result<PathBuf, Error> {
         use fs_extra::dir::CopyOptions;
+
+        if Path::new(BUNDLED_SOURCE_PATH).read_dir()?.next().is_none() {
+            eprintln!("The webrtc-audio-processing source directory is empty.");
+            eprintln!("See the crate README for installation instructions.");
+            eprintln!("Remember to clone the repo recursively if building from source.");
+            panic!("Aborting compilation because bundled source directory is empty.")
+        }
 
         let out_dir = out_dir();
         let mut options = CopyOptions::new();
@@ -77,11 +85,6 @@ mod webrtc {
 
     pub(super) fn build_if_necessary() -> Result<(), Error> {
         let build_dir = copy_source_to_out_dir()?;
-        if build_dir.read_dir()?.next().is_none() {
-            eprintln!("The webrtc-audio-processing build directory is empty");
-            eprintln!("See the crate README for installation instructions");
-            eprintln!("Remember to clone the repo recursively if building from source.");
-        }
 
         if cfg!(target_os = "macos") {
             run_command(&build_dir, "glibtoolize", None)?;

--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -71,7 +71,7 @@ mod webrtc {
             eprintln!("The webrtc-audio-processing source directory is empty.");
             eprintln!("See the crate README for installation instructions.");
             eprintln!("Remember to clone the repo recursively if building from source.");
-            panic!("Aborting compilation because bundled source directory is empty.")
+            bail!("Aborting compilation because bundled source directory is empty.");
         }
 
         let out_dir = out_dir();

--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -77,6 +77,11 @@ mod webrtc {
 
     pub(super) fn build_if_necessary() -> Result<(), Error> {
         let build_dir = copy_source_to_out_dir()?;
+        if build_dir.read_dir()?.next().is_none() {
+            eprintln!("The webrtc-audio-processing build directory is empty");
+            eprintln!("See the crate README for installation instructions");
+            eprintln!("Remember to clone the repo recursively if building from source.");
+        }
 
         if cfg!(target_os = "macos") {
             run_command(&build_dir, "glibtoolize", None)?;


### PR DESCRIPTION
I was trying to build a project that relies on `webrtc-audio-processing-sys`, but I was getting a really opaque error about `./configure` missing. After hunting down the bug with @strohel (I forgot to clone recursively), I've put in this PR to help others reach the same conclusion more quickly. This is more of a warning than an error (as we don't panic upon detecting an empty directory) but if needed we could run the source build process in another thread and check that it exits correctly to make this a hard error. 