### PR TITLE
Fix clippy 1.84 lints - including small API changes

### DIFF
--- a/examples/karaoke.rs
+++ b/examples/karaoke.rs
@@ -1,9 +1,7 @@
 // This example loops the microphone input back to the speakers, while applying echo cancellation,
 // creating an experience similar to Karaoke microphones. It uses PortAudio as an interface to the
 // underlying audio devices.
-use ctrlc;
 use failure::Error;
-use portaudio;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -85,15 +83,15 @@ fn main() -> Result<(), Error> {
 
     let mut stream = pa.open_non_blocking_stream(
         stream_settings,
-        move |portaudio::DuplexStreamCallbackArgs { in_buffer, mut out_buffer, frames, .. }| {
+        move |portaudio::DuplexStreamCallbackArgs { in_buffer, out_buffer, frames, .. }| {
             assert_eq!(frames as u32, FRAMES_PER_BUFFER);
 
-            processed.copy_from_slice(&in_buffer);
+            processed.copy_from_slice(in_buffer);
             processor.process_capture_frame(&mut processed).unwrap();
 
             // Play back the processed audio capture.
             out_buffer.copy_from_slice(&processed);
-            processor.process_render_frame(&mut out_buffer).unwrap();
+            processor.process_render_frame(out_buffer).unwrap();
 
             portaudio::Continue
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl Processor {
     /// with NUM_SAMPLES_PER_FRAME samples.
     pub fn process_capture_frame_noninterleaved(
         &mut self,
-        frame: &mut Vec<Vec<f32>>,
+        frame: &mut [Vec<f32>],
     ) -> Result<(), Error> {
         self.inner.process_capture_frame(frame)
     }
@@ -97,7 +97,7 @@ impl Processor {
     /// representing a channel with NUM_SAMPLES_PER_FRAME samples.
     pub fn process_render_frame_noninterleaved(
         &mut self,
-        frame: &mut Vec<Vec<f32>>,
+        frame: &mut [Vec<f32>],
     ) -> Result<(), Error> {
         self.inner.process_render_frame(frame)
     }
@@ -184,7 +184,7 @@ impl AudioProcessing {
         }
     }
 
-    fn process_capture_frame(&self, frame: &mut Vec<Vec<f32>>) -> Result<(), Error> {
+    fn process_capture_frame(&self, frame: &mut [Vec<f32>]) -> Result<(), Error> {
         let mut frame_ptr = frame.iter_mut().map(|v| v.as_mut_ptr()).collect::<Vec<*mut f32>>();
         unsafe {
             let code = ffi::process_capture_frame(self.inner, frame_ptr.as_mut_ptr());
@@ -196,7 +196,7 @@ impl AudioProcessing {
         }
     }
 
-    fn process_render_frame(&self, frame: &mut Vec<Vec<f32>>) -> Result<(), Error> {
+    fn process_render_frame(&self, frame: &mut [Vec<f32>]) -> Result<(), Error> {
         let mut frame_ptr = frame.iter_mut().map(|v| v.as_mut_ptr()).collect::<Vec<*mut f32>>();
         unsafe {
             let code = ffi::process_render_frame(self.inner, frame_ptr.as_mut_ptr());
@@ -412,8 +412,8 @@ mod tests {
             ..InitializationConfig::default()
         };
         let mut ap = Processor::new(&config).unwrap();
-        
-        // tweak params outside of config 
+
+        // tweak params outside of config
         ap.set_output_will_be_muted(true);
         ap.set_stream_key_pressed(true);
 
@@ -427,5 +427,4 @@ mod tests {
 
         // it shouldn't crash
     }
-
 }


### PR DESCRIPTION
The API change is that various process_{capture,render}_frame() methods now take `&mut [Vec<f32>]` instead of `&mut Vec<Vec<f32>>`.

Such a change should be compatible, as every `&mut Vec<_>` is also a `&mut [_]`, but strictly-speaking it may be a semver-breaking change? Maybe we shouldn't care that much.

CC @jacksongoode (looks like I cannot assign you as a reviewer).