### PR TITLE
fix: make it build on android with cargo-apk

### DIFF
--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -100,9 +100,11 @@ mod webrtc {
         run_command(&build_dir, "automake", Some(&["--add-missing", "--copy"]))?;
         run_command(&build_dir, "autoconf", None)?;
 
+        let target = std::env::var("TARGET").unwrap();
         autotools::Config::new(build_dir)
             .cflag("-fPIC")
             .cxxflag("-fPIC")
+            .config_option("host", Some(&target))
             .disable_shared()
             .enable_static()
             .build();


### PR DESCRIPTION
I'm building a Rust android app with `webrtc-audio-processing`. I failed to get it to cross-compile successfully with the default setup. I'm using `cargo apk` for the build, tried `xbuild` too, same. This change here made it work, and doesn't seem to cause any issues for non-android builds.