### PR TITLE
Fix issues when building for other targets on macOS

### DIFF
--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -150,6 +150,7 @@ mod webrtc {
 fn main() -> Result<()> {
     webrtc::build_if_necessary()?;
     let (include_dirs, lib_dirs) = webrtc::get_build_paths()?;
+    let target_os = env::var("CARGO_CFG_TARGET_OS")?;
 
     for dir in &lib_dirs {
         println!("cargo:rustc-link-search=native={}", dir.display());
@@ -162,14 +163,14 @@ fn main() -> Result<()> {
         println!("cargo:rustc-link-lib=dylib=webrtc-audio-processing-2");
     }
 
-    if cfg!(target_os = "macos") {
+    if target_os == "macos" {
         println!("cargo:rustc-link-lib=framework=CoreFoundation");
     }
 
     let mut cc_build = cc::Build::new();
 
     // set mac minimum version
-    if cfg!(target_os = "macos") {
+    if target_os == "macos" {
         let min_version = match env::var(DEPLOYMENT_TARGET_VAR) {
             Ok(ver) => ver,
             Err(_) => {


### PR DESCRIPTION
Use the CARGO_CFG_TARGET_OS environment variable instead of the cfg! macro to identify the target os. This fixes errors when building for iOS targets on a macOS host.