### PR TITLE
Make the `AudioProcessing` API public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,9 +168,9 @@ impl Processor {
     }
 }
 
-/// `AudioProcessing` provides an access to webrtc's audio processing e.g. echo cancellation and
+/// `AudioProcessing` provides access to webrtc's audio processing e.g. echo cancellation and
 /// automatic gain control.
-/// This is a low level API that may require wrapping in your Arc to be shared between threads,
+/// This is a low level API that may require wrapping in an Arc to be shared between threads,
 /// depending on the use case. See [`Processor`] for a simple wrapper around this API that enables
 /// sharing the processor between threads.
 pub struct AudioProcessing {


### PR DESCRIPTION
...so that we can do a more precise locking needed in https://github.com/tonarino/portal/pull/5565#discussion_r2445505557