### PR TITLE
Remove enabled and simplify fallback defaults

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -284,19 +284,13 @@ impl FromConfig<Option<config::GainController2>> for ffi::AudioProcessing_Config
         let Some(other) = other else { return Self { enabled: false, ..Self::default() } };
         Self {
             enabled: true,
-            input_volume_controller: other.input_volume_controller.into_ffi(),
+            input_volume_controller:
+                ffi::AudioProcessing_Config_GainController2_InputVolumeController {
+                    enabled: other.input_volume_controller_enabled,
+                },
             adaptive_digital: other.adaptive_digital.into_ffi(),
             fixed_digital: other.fixed_digital.into_ffi(),
         }
-    }
-}
-
-impl FromConfig<Option<config::InputVolumeController>>
-    for ffi::AudioProcessing_Config_GainController2_InputVolumeController
-{
-    fn from_config(other: Option<config::InputVolumeController>) -> Self {
-        let Some(_) = other else { return Self { enabled: false } };
-        Self { enabled: true }
     }
 }
 

--- a/webrtc-audio-processing-config/src/lib.rs
+++ b/webrtc-audio-processing-config/src/lib.rs
@@ -386,10 +386,10 @@ pub enum ClippingPredictorMode {
 #[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct GainController2 {
-    /// Parameters for the input volume controller, which adjusts the input
+    /// Enables the input volume controller, which adjusts the input
     /// volume applied when the audio is captured (e.g., microphone volume on
     /// a soundcard, input volume on HAL).
-    pub input_volume_controller: Option<InputVolumeController>,
+    pub input_volume_controller_enabled: bool,
     /// Parameters for the adaptive digital controller, which adjusts and
     /// applies a digital gain after echo cancellation and after noise
     /// suppression.
@@ -399,13 +399,6 @@ pub struct GainController2 {
     /// limiter.
     pub fixed_digital: FixedDigital,
 }
-
-/// Parameters for the input volume controller, which adjusts the input
-/// volume applied when the audio is captured (e.g., microphone volume on
-/// a soundcard, input volume on HAL).
-#[derive(Debug, Default, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
-pub struct InputVolumeController {}
 
 /// Parameters for the adaptive digital controller, which adjusts and
 /// applies a digital gain after echo cancellation and after noise


### PR DESCRIPTION
This should wait on https://github.com/tonarino/webrtc-audio-processing/pull/68 otherwise things will be messy.

This gets rid of the unneeded `enabled` fields & makes the structs optional.

