### PR TITLE
Derive Copy for all config types incl. experimental AEC3

### DIFF
--- a/examples/karaoke.rs
+++ b/examples/karaoke.rs
@@ -36,9 +36,9 @@ struct Args {
 }
 
 fn create_processor(config: &AppConfig) -> Result<Processor, Error> {
-    let processor = Processor::with_aec3_config(SAMPLE_RATE as u32, config.aec3.clone())?;
+    let processor = Processor::with_aec3_config(SAMPLE_RATE as u32, config.aec3)?;
 
-    processor.set_config(config.config.clone());
+    processor.set_config(config.config);
     Ok(processor)
 }
 

--- a/examples/recording.rs
+++ b/examples/recording.rs
@@ -185,7 +185,7 @@ fn main() -> Result<(), Error> {
 
     let processor = Arc::new(Processor::new(AUDIO_SAMPLE_RATE)?);
 
-    processor.set_config(opt.config.clone());
+    processor.set_config(opt.config);
 
     let running = Arc::new(AtomicBool::new(true));
 

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// aec3_config.suppressor.dominant_nearend_detection.snr_threshold = 30.0;
 /// assert!(aec3_config.validate());
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct EchoCanceller3Config(ffi::EchoCanceller3Config);
 

--- a/webrtc-audio-processing-config/src/lib.rs
+++ b/webrtc-audio-processing-config/src/lib.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// by changing the default values in this [`Config`] struct.
 /// The config is applied by passing the struct to the
 /// [`Processor::set_config()`](webrtc-audio-processing::Processor::set_config()) method.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct Config {
     /// Sets the properties of the audio processing pipeline.
@@ -34,7 +34,7 @@ pub struct Config {
 }
 
 /// Sets the properties of the audio processing pipeline.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct Pipeline {
     /// Maximum allowed processing rate used internally.
@@ -76,7 +76,7 @@ pub enum DownmixMethod {
 }
 
 /// A choice of capture-side pre-amplification/volume adjustment.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CaptureAmplifier {
     /// Use the legacy PreAmplifier.
@@ -88,7 +88,7 @@ pub enum CaptureAmplifier {
 /// The `PreAmplifier` amplifies the capture signal before any other processing is done.
 /// TODO(webrtc:5298): Will be deprecated to use the pre-gain functionality
 /// in capture_level_adjustment instead.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct PreAmplifier {
     /// Fixed linear gain multiplier. The default is 1.0 (no effect).
@@ -103,7 +103,7 @@ impl Default for PreAmplifier {
 
 /// Functionality for general level adjustment in the capture pipeline. This
 /// should not be used together with the legacy PreAmplifier functionality.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct CaptureLevelAdjustment {
     /// The `pre_gain_factor` scales the signal before any processing is done.
@@ -123,7 +123,7 @@ impl Default for CaptureLevelAdjustment {
 }
 
 /// Analog mic gain emulation for capture level adjustment.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct AnalogMicGainEmulation {
     /// Initial analog gain level to use for the emulated analog gain. Must
@@ -138,7 +138,7 @@ impl Default for AnalogMicGainEmulation {
 }
 
 /// HPF (high-pass filter) configuration.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct HighPassFilter {
     /// Whether or not HPF should be applied in the full-band (i.e. 20 – 20,000 Hz).
@@ -156,7 +156,7 @@ impl Default for HighPassFilter {
 ///
 /// Functionality in the C++ library that we don't yet expose:
 /// - EchoCanceller::enforce_high_pass_filtering: hard-coded to true on Full, false on Mobile
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum EchoCanceller {
     /// Use low-complexity AEC implementation that is optimized for mobile.
@@ -181,7 +181,7 @@ impl Default for EchoCanceller {
 }
 
 /// Enables background noise suppression.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct NoiseSuppression {
     /// Determines the aggressiveness of the suppression. Increasing the level will reduce the
@@ -215,7 +215,7 @@ pub enum NoiseSuppressionLevel {
 }
 
 /// A choice of the gain controller implementation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GainController {
     /// Legacy gain controller 1.
@@ -230,7 +230,7 @@ pub enum GainController {
 /// in the analog mode, prescribing an analog gain to be applied at the audio
 /// HAL.
 /// Recommended to be enabled on the client-side.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct GainController1 {
     /// AGC mode.
@@ -300,7 +300,7 @@ pub enum GainControllerMode {
 }
 
 /// Enables the analog gain controller functionality.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct AnalogGainController {
     /// TODO(bugs.webrtc.org/7494): Will be deprecated.
@@ -338,7 +338,7 @@ impl Default for AnalogGainController {
 }
 
 /// Enables clipping prediction functionality.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct ClippingPredictor {
     /// Mode.
@@ -390,7 +390,7 @@ pub enum ClippingPredictorMode {
 /// AGC2 brings the captured audio signal to the desired level by combining
 /// three different controllers (namely, input volume controller, adaptive
 /// digital controller and fixed digital controller) and a limiter.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Copy, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct GainController2 {
     /// Enables the input volume controller, which adjusts the input
@@ -410,7 +410,7 @@ pub struct GainController2 {
 /// Parameters for the adaptive digital controller, which adjusts and
 /// applies a digital gain after echo cancellation and after noise
 /// suppression.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct AdaptiveDigital {
     /// Headroom (dB).
@@ -440,7 +440,7 @@ impl Default for AdaptiveDigital {
 /// Parameters for the fixed digital controller, which applies a fixed
 /// digital gain after the adaptive digital controller and before the
 /// limiter.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(default))]
 pub struct FixedDigital {
     /// By setting `gain_db` to a value greater than zero, the limiter can be


### PR DESCRIPTION
There is no reason not to, and this greatly improves caller convenience.

`Config` is mere 80 bytes. `EchoCanceller3Config` is 608 bytes, but that's still reasonable.

Also per https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits