### PR TITLE
Document that passing AEC3 config force-enables echo canceller

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl Processor {
     ///   functionality). You can use [`experimental::EchoCanceller3Config::multichannel_default()`]
     ///
     /// To change the AEC3 configuration at runtime, the [`Processor`] needs to be currently
-    /// recreated. This limitation could be eventually lifted, see issue #77.
+    /// recreated. This limitation could be eventually lifted, see PR #77.
     #[cfg(feature = "experimental-aec3-config")]
     pub fn with_aec3_config(
         sample_rate_hz: u32,


### PR DESCRIPTION
As described in https://github.com/tonarino/webrtc-audio-processing/pull/77#issuecomment-3847227065