### PR TITLE
Test case/fix for crash when using AEC3 + analyze_linear_aec_output

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,14 +30,6 @@ impl FromConfig<Config> for ffi::AudioProcessing_Config {
             None => (None, None),
         };
 
-        let mut echo_canceller =
-            ffi::AudioProcessing_Config_EchoCanceller::from_config(other.echo_canceller);
-        echo_canceller.export_linear_aec_output = if let Some(ns) = &other.noise_suppression {
-            ns.analyze_linear_aec_output
-        } else {
-            false
-        };
-
         // Transient suppressor is being deprecated.
         let transient_suppression =
             ffi::AudioProcessing_Config_TransientSuppression { enabled: false };
@@ -53,7 +45,7 @@ impl FromConfig<Config> for ffi::AudioProcessing_Config {
             pre_amplifier: pre_amplifier.into_ffi(),
             capture_level_adjustment: capture_level_adjustment.into_ffi(),
             high_pass_filter: other.high_pass_filter.into_ffi(),
-            echo_canceller,
+            echo_canceller: other.echo_canceller.into_ffi(),
             noise_suppression: other.noise_suppression.into_ffi(),
             transient_suppression,
             gain_controller1: gain_controller1.into_ffi(),
@@ -139,8 +131,7 @@ impl FromConfig<Option<EchoCanceller>> for ffi::AudioProcessing_Config_EchoCance
             // This is just another way to enable the high pass filter on C++ side, but we already
             // have an explicit config for that, so hard-code to false.
             enforce_high_pass_filtering: false,
-            // This may be still enabled by FromConfig<Config> for ffi::AudioProcessing_Config in
-            // case of Full AEC3 mode.
+            // This may be still enabled by `Processor::set_config()`
             export_linear_aec_output: false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,17 +132,18 @@ pub struct Processor {
     /// If the value cannot be exactly represented as i32 (e.g. u32::MAX), it denotes _not set_.
     stream_delay_ms: AtomicU32,
 
-    /// Whether we use explicit AEC3 configuration *and* it has filter.export_linear_aec_output
-    /// enabled. A prerequisite to using [`config::NoiseSuppression::analyze_linear_aec_output`].
-    has_aec3_export_linear_aec_output: bool,
+    /// If experimental AEC3 configuration was passed to constructor, this contains its
+    /// filter.export_linear_aec_output value. Otherwise this is `None`.
+    /// A prerequisite to using [`config::NoiseSuppression::analyze_linear_aec_output`].
+    aec3_config_export_linear_aec_output: Option<bool>,
 }
 
 impl Processor {
     /// Creates a new [`Processor`]. Detailed general configuration can be be passed to
     /// [`Self::set_config()`] at any time during processing.
     pub fn new(sample_rate_hz: u32) -> Result<Self, Error> {
-        let has_aec3_export_linear_aec_output = false;
-        Self::new_with_ptr(sample_rate_hz, null_mut(), has_aec3_export_linear_aec_output)
+        let aec3_config_export_linear_aec_output = None;
+        Self::new_with_ptr(sample_rate_hz, null_mut(), aec3_config_export_linear_aec_output)
     }
 
     /// [Highly experimental]
@@ -164,15 +165,20 @@ impl Processor {
         sample_rate_hz: u32,
         mut aec3_config: experimental::EchoCanceller3Config,
     ) -> Result<Self, Error> {
-        let has_aec3_export_linear_aec_output = aec3_config.filter.export_linear_aec_output;
-        Self::new_with_ptr(sample_rate_hz, &raw mut *aec3_config, has_aec3_export_linear_aec_output)
+        let aec3_config_export_linear_aec_output =
+            Some(aec3_config.filter.export_linear_aec_output);
+        Self::new_with_ptr(
+            sample_rate_hz,
+            &raw mut *aec3_config,
+            aec3_config_export_linear_aec_output,
+        )
     }
 
     /// Pass null ptr in `aec3_config` to use its default config.
     fn new_with_ptr(
         sample_rate_hz: u32,
         aec3_config: *mut ffi::EchoCanceller3Config,
-        has_aec3_export_linear_aec_output: bool,
+        aec3_config_export_linear_aec_output: Option<bool>,
     ) -> Result<Self, Error> {
         let mut code = 0;
         let inner = unsafe { ffi::create_audio_processing(aec3_config, &mut code) };
@@ -190,7 +196,7 @@ impl Processor {
             inner,
             sample_rate_hz,
             stream_delay_ms: AtomicU32::new(u32::MAX),
-            has_aec3_export_linear_aec_output,
+            aec3_config_export_linear_aec_output,
         })
     }
 
@@ -306,7 +312,7 @@ impl Processor {
         let use_linear_aec_output =
             config.noise_suppression.is_some_and(|ns| ns.analyze_linear_aec_output)
                 && config.echo_canceller.is_some_and(|ec| matches!(ec, EchoCanceller::Full { .. }))
-                && self.has_aec3_export_linear_aec_output;
+                && self.aec3_config_export_linear_aec_output == Some(true);
 
         // Extract the stream delay to our cache (it is a runtime concept for AEC, not a config).
         let stream_delay_ms_opt = match config.echo_canceller {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -996,4 +996,25 @@ mod tests {
             "Echo metrics should remain available after config change"
         );
     }
+
+    // Test for https://github.com/tonarino/webrtc-audio-processing/issues/91
+    #[test]
+    fn test_full_aec_with_linear_aec_output_crash() {
+        let context = TestContext::new(1, None);
+
+        context.processor.set_config(Config {
+            echo_canceller: Some(EchoCanceller::Full { stream_delay_ms: None }),
+            noise_suppression: Some(config::NoiseSuppression {
+                analyze_linear_aec_output: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let mut render = context.generate_sine_frame(440.0, 0.0);
+        let mut capture = render.clone();
+
+        context.processor.process_render_frame(&mut render).unwrap();
+        context.processor.process_capture_frame(&mut capture).unwrap();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod stats;
 #[cfg(feature = "experimental-aec3-config")]
 pub mod experimental;
 
-use crate::config::{EchoCanceller, IntoFfi};
+use crate::config::{EchoCanceller, FromConfig};
 use std::{
     convert::TryFrom,
     error, fmt,
@@ -125,18 +125,24 @@ fn result_from_code<T>(on_success: T, error_code: i32) -> Result<T, Error> {
 pub struct Processor {
     inner: AudioProcessingPtr,
     sample_rate_hz: u32,
+
     /// The stream_delay extracted from config. Underlying C++ library wants us to set this before
     /// every process_capture_frame() call in many cases (Full AEC3 with custom delay, Mobile AECM).
     ///
     /// If the value cannot be exactly represented as i32 (e.g. u32::MAX), it denotes _not set_.
     stream_delay_ms: AtomicU32,
+
+    /// Whether we use explicit AEC3 configuration *and* it has filter.export_linear_aec_output
+    /// enabled. A prerequisite to using [`config::NoiseSuppression::analyze_linear_aec_output`].
+    has_aec3_export_linear_aec_output: bool,
 }
 
 impl Processor {
     /// Creates a new [`Processor`]. Detailed general configuration can be be passed to
     /// [`Self::set_config()`] at any time during processing.
     pub fn new(sample_rate_hz: u32) -> Result<Self, Error> {
-        Self::new_with_ptr(sample_rate_hz, null_mut())
+        let has_aec3_export_linear_aec_output = false;
+        Self::new_with_ptr(sample_rate_hz, null_mut(), has_aec3_export_linear_aec_output)
     }
 
     /// [Highly experimental]
@@ -158,13 +164,15 @@ impl Processor {
         sample_rate_hz: u32,
         mut aec3_config: experimental::EchoCanceller3Config,
     ) -> Result<Self, Error> {
-        Self::new_with_ptr(sample_rate_hz, &raw mut *aec3_config)
+        let has_aec3_export_linear_aec_output = aec3_config.filter.export_linear_aec_output;
+        Self::new_with_ptr(sample_rate_hz, &raw mut *aec3_config, has_aec3_export_linear_aec_output)
     }
 
     /// Pass null ptr in `aec3_config` to use its default config.
     fn new_with_ptr(
         sample_rate_hz: u32,
         aec3_config: *mut ffi::EchoCanceller3Config,
+        has_aec3_export_linear_aec_output: bool,
     ) -> Result<Self, Error> {
         let mut code = 0;
         let inner = unsafe { ffi::create_audio_processing(aec3_config, &mut code) };
@@ -178,7 +186,12 @@ impl Processor {
         let inner = AudioProcessingPtr(inner);
 
         // u32::MAX to denote stream_delay_ms not (yet) set.
-        Ok(Self { inner, sample_rate_hz, stream_delay_ms: AtomicU32::new(u32::MAX) })
+        Ok(Self {
+            inner,
+            sample_rate_hz,
+            stream_delay_ms: AtomicU32::new(u32::MAX),
+            has_aec3_export_linear_aec_output,
+        })
     }
 
     /// Processes and modifies the audio frame from a capture device by applying
@@ -290,6 +303,11 @@ impl Processor {
     /// Only submodules whose config has changed are reinitialized. If the passed config is the same
     /// as current config, the overhead is only the locking and doing some comparisons.
     pub fn set_config(&self, config: Config) {
+        let use_linear_aec_output =
+            config.noise_suppression.is_some_and(|ns| ns.analyze_linear_aec_output)
+                && config.echo_canceller.is_some_and(|ec| matches!(ec, EchoCanceller::Full { .. }))
+                && self.has_aec3_export_linear_aec_output;
+
         // Extract the stream delay to our cache (it is a runtime concept for AEC, not a config).
         let stream_delay_ms_opt = match config.echo_canceller {
             Some(EchoCanceller::Full { stream_delay_ms }) => stream_delay_ms,
@@ -300,8 +318,11 @@ impl Processor {
         let stream_delay_ms = stream_delay_ms_opt.map_or(u32::MAX, u32::from);
         self.stream_delay_ms.store(stream_delay_ms, Ordering::Relaxed);
 
+        let mut ffi_config = ffi::AudioProcessing_Config::from_config(config);
+        ffi_config.echo_canceller.export_linear_aec_output = use_linear_aec_output;
+
         unsafe {
-            ffi::set_config(*self.inner, &config.into_ffi());
+            ffi::set_config(*self.inner, &ffi_config);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -997,10 +997,35 @@ mod tests {
         );
     }
 
-    // Test for https://github.com/tonarino/webrtc-audio-processing/issues/91
+    /// First test for https://github.com/tonarino/webrtc-audio-processing/issues/91
     #[test]
-    fn test_full_aec_with_linear_aec_output_crash() {
+    fn test_full_aec_with_linear_aec_output_misconfiguration() {
         let context = TestContext::new(1, None);
+
+        context.processor.set_config(Config {
+            echo_canceller: Some(EchoCanceller::Full { stream_delay_ms: None }),
+            noise_suppression: Some(config::NoiseSuppression {
+                analyze_linear_aec_output: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let mut render = context.generate_sine_frame(440.0, 0.0);
+        let mut capture = render.clone();
+
+        context.processor.process_render_frame(&mut render).unwrap();
+        context.processor.process_capture_frame(&mut capture).unwrap();
+    }
+
+    /// Second test for https://github.com/tonarino/webrtc-audio-processing/issues/91
+    #[test]
+    #[cfg(feature = "experimental-aec3-config")]
+    fn test_full_aec_with_linear_aec_output_correct() {
+        let mut aec3_config = experimental::EchoCanceller3Config::default();
+        aec3_config.filter.export_linear_aec_output = true;
+
+        let context = TestContext::new(1, Some(aec3_config));
 
         context.processor.set_config(Config {
             echo_canceller: Some(EchoCanceller::Full { stream_delay_ms: None }),

--- a/webrtc-audio-processing-config/src/lib.rs
+++ b/webrtc-audio-processing-config/src/lib.rs
@@ -213,8 +213,10 @@ pub struct NoiseSuppression {
     pub level: NoiseSuppressionLevel,
 
     /// Analyze the output of the linear AEC instead of the capture frame.
-    /// Activates the `export_linear_aec_output` flag of the echo canceller.
-    /// Has no effect if echo cancellation is not enabled or is of the Mobile AECM type.
+    ///
+    /// Only has effect if:
+    /// - echo cancellation is enabled and of Full (AEC3) type
+    /// - experimental AEC3 config was passed with `filter.export_linear_aec_output` = true.
     pub analyze_linear_aec_output: bool,
 }
 


### PR DESCRIPTION
- fixes #91

This fix is a bit tricky, we work-around it by extending the list of conditions that must hold for `analyze_linear_aec_output` to have any effect.