### PR TITLE
sys: add aarch64 linux lib path

### DIFF
--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -156,6 +156,8 @@ mod webrtc {
             out_dir().join("lib"),
             // Ubuntu Linux (our CI)
             out_dir().join("lib").join("x86_64-linux-gnu"),
+            // Ubuntu Linux (Arm 64bit)
+            out_dir().join("lib").join("aarch64-linux-gnu"),
             // Gentoo Linux (x86_64 multilib)
             out_dir().join("lib64"),
         ];


### PR DESCRIPTION
This PR adds the appropriate library path to allow `webrtc-audio-processing-sys` to build for `aarch64-unknown-linux-gnu` targets.