### PR TITLE
Exclude `portaudio` feature flag on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ categories = ["multimedia::audio"]
 license-file = "COPYING"
 
 [package.metadata.docs.rs]
-# Document with all features enabled.
-all-features = true
+# Document with all features, but exclude portaudio, whose build fails on docs.rs (tries to access
+# internet). Extend this list then adding features (optional dependencies).
+features = ["schemars", "serde", "strum", "bundled", "experimental-aec3-config", "experimental-unlink-ns"]
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
`portaudio` build fails on docs.rs, because it tries to download portaudio sources from the network, but docs.rs builds run without network: https://docs.rs/crate/webrtc-audio-processing/latest/builds/3091546

Further work may be needed, but this gets us to the next error (likely webrtc-audio-processing trying to download abseil-cpp -- but we can do something about it).

https://github.com/tonarino/webrtc-audio-processing/pull/96 also helps with docs.rs build.