### PR TITLE
Get residual echo metrics & assert unpopulated metrics 

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -7,24 +7,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Stats {
-    /// True if voice is detected in the current frame.
-    pub voice_detected: Option<bool>,
     /// AEC stats: ERL = 10log_10(P_far / P_echo)
     pub echo_return_loss: Option<f64>,
     /// AEC stats: ERLE = 10log_10(P_echo / P_out)
     pub echo_return_loss_enhancement: Option<f64>,
-    /// AEC stats: Fraction of time that the AEC linear filter is divergent, in a 1-second
-    /// non-overlapped aggregation window.
-    pub divergent_filter_fraction: Option<f64>,
-
-    /// The delay median in milliseconds. The values are aggregated until the first call to
-    /// [`Processor::get_stats()`](crate::Processor::get_stats()) and afterwards aggregated and
-    /// updated every second.
-    pub delay_median_ms: Option<u32>,
-    /// The delay standard deviation in milliseconds. The values are aggregated until the first
-    /// call to [`Processor::get_stats()`](crate::Processor::get_stats()) and afterwards aggregated
-    /// and updated every second.
-    pub delay_standard_deviation_ms: Option<u32>,
 
     /// Residual echo detector likelihood.
     pub residual_echo_likelihood: Option<f64>,
@@ -40,13 +26,8 @@ pub struct Stats {
 impl From<ffi::Stats> for Stats {
     fn from(other: ffi::Stats) -> Self {
         Self {
-            voice_detected: other.voice_detected.into(),
             echo_return_loss: other.echo_return_loss.into(),
             echo_return_loss_enhancement: other.echo_return_loss_enhancement.into(),
-            divergent_filter_fraction: other.divergent_filter_fraction.into(),
-            delay_median_ms: Option::<i32>::from(other.delay_median_ms).map(|v| v as u32),
-            delay_standard_deviation_ms: Option::<i32>::from(other.delay_standard_deviation_ms)
-                .map(|v| v as u32),
             residual_echo_likelihood: other.residual_echo_likelihood.into(),
             residual_echo_likelihood_recent_max: other.residual_echo_likelihood_recent_max.into(),
             delay_ms: Option::<i32>::from(other.delay_ms).map(|v| v as u32),

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -13,8 +13,10 @@ pub struct Stats {
     pub echo_return_loss_enhancement: Option<f64>,
 
     /// Residual echo detector likelihood.
+    #[cfg(feature = "bundled")]
     pub residual_echo_likelihood: Option<f64>,
     /// Maximum residual echo likelihood from the last time period.
+    #[cfg(feature = "bundled")]
     pub residual_echo_likelihood_recent_max: Option<f64>,
 
     /// The instantaneous delay estimate produced in the AEC. The unit is in milliseconds and the
@@ -28,7 +30,9 @@ impl From<ffi::Stats> for Stats {
         Self {
             echo_return_loss: other.echo_return_loss.into(),
             echo_return_loss_enhancement: other.echo_return_loss_enhancement.into(),
+            #[cfg(feature = "bundled")]
             residual_echo_likelihood: other.residual_echo_likelihood.into(),
+            #[cfg(feature = "bundled")]
             residual_echo_likelihood_recent_max: other.residual_echo_likelihood_recent_max.into(),
             delay_ms: Option::<i32>::from(other.delay_ms).map(|v| v as u32),
         }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -13,10 +13,12 @@ pub struct Stats {
     pub echo_return_loss_enhancement: Option<f64>,
 
     /// Residual echo detector likelihood.
-    #[cfg(feature = "bundled")]
+    ///
+    /// Always `None` when not using the `bundled` feature.
     pub residual_echo_likelihood: Option<f64>,
     /// Maximum residual echo likelihood from the last time period.
-    #[cfg(feature = "bundled")]
+    ///
+    /// Always `None` when not using the `bundled` feature.
     pub residual_echo_likelihood_recent_max: Option<f64>,
 
     /// The instantaneous delay estimate produced in the AEC. The unit is in milliseconds and the
@@ -30,9 +32,7 @@ impl From<ffi::Stats> for Stats {
         Self {
             echo_return_loss: other.echo_return_loss.into(),
             echo_return_loss_enhancement: other.echo_return_loss_enhancement.into(),
-            #[cfg(feature = "bundled")]
             residual_echo_likelihood: other.residual_echo_likelihood.into(),
-            #[cfg(feature = "bundled")]
             residual_echo_likelihood_recent_max: other.residual_echo_likelihood_recent_max.into(),
             delay_ms: Option::<i32>::from(other.delay_ms).map(|v| v as u32),
         }

--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -402,8 +402,13 @@ fn main() -> Result<()> {
         .includes(&include_dirs)
         .flag("-std=c++17")
         .flag("-Wno-unused-parameter")
-        .out_dir(out_dir())
-        .compile("webrtc_audio_processing_wrapper");
+        .out_dir(out_dir());
+
+    // Include bundled source headers for internal classes (e.g. ResidualEchoDetector)
+    // that are not exposed in the system package.
+    cc_build.include(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("webrtc-audio-processing/webrtc"));
+
+    cc_build.compile("webrtc_audio_processing_wrapper");
 
     // The the cc and bindgen commands emit `cargo:rerun-if-env-changed=...`, and these deactivate
     // the default behavior to rerun if _any_ source file changes. So state these explicitly.

--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -406,7 +406,13 @@ fn main() -> Result<()> {
 
     // Include bundled source headers for internal classes (e.g. ResidualEchoDetector)
     // that are not exposed in the system package.
-    cc_build.include(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("webrtc-audio-processing/webrtc"));
+    #[cfg(feature = "bundled")]
+    {
+        cc_build.include(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("webrtc-audio-processing/webrtc"),
+        );
+        cc_build.define("WEBRTC_HAS_INTERNAL_HEADERS", None);
+    }
 
     cc_build.compile("webrtc_audio_processing_wrapper");
 

--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -408,9 +408,6 @@ fn main() -> Result<()> {
     // that are not exposed in the system package.
     #[cfg(feature = "bundled")]
     {
-        cc_build.include(
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("webrtc-audio-processing/webrtc"),
-        );
         cc_build.define("WEBRTC_HAS_INTERNAL_HEADERS", None);
     }
 

--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -404,12 +404,9 @@ fn main() -> Result<()> {
         .flag("-Wno-unused-parameter")
         .out_dir(out_dir());
 
-    // Include bundled source headers for internal classes (e.g. ResidualEchoDetector)
-    // that are not exposed in the system package.
+    // Inform wrapper code that headers for internal classes (ResidualEchoDetector) are available.
     #[cfg(feature = "bundled")]
-    {
-        cc_build.define("WEBRTC_HAS_INTERNAL_HEADERS", None);
-    }
+    cc_build.define("WEBRTC_HAS_INTERNAL_HEADERS", None);
 
     cc_build.compile("webrtc_audio_processing_wrapper");
 

--- a/webrtc-audio-processing-sys/src/lib.rs
+++ b/webrtc-audio-processing-sys/src/lib.rs
@@ -205,15 +205,13 @@ mod tests {
             println!("Stats:\n{:#?}", stats);
             assert!(stats.echo_return_loss.has_value);
             assert!(stats.echo_return_loss_enhancement.has_value);
+            assert!(stats.residual_echo_likelihood.has_value);
+            assert!(stats.residual_echo_likelihood_recent_max.has_value);
             assert!(stats.delay_ms.has_value);
 
-            // The following stats are not asserted because they are not reliably populated
-            // in this test environment.
-            // assert!(stats.voice_detected.has_value);
-            // assert!(stats.residual_echo_likelihood.has_value);
-            // assert!(stats.residual_echo_likelihood_recent_max.has_value);
-
-            // TODO: Investigate why these stats are not filled.
+            // Fields declared in upstream but never populated in v2.1.
+            // See: webrtc/api/audio/audio_processing_statistics.h
+            assert!(!stats.voice_detected.has_value);
             assert!(!stats.divergent_filter_fraction.has_value);
             assert!(!stats.delay_median_ms.has_value);
             assert!(!stats.delay_standard_deviation_ms.has_value);

--- a/webrtc-audio-processing-sys/src/lib.rs
+++ b/webrtc-audio-processing-sys/src/lib.rs
@@ -205,9 +205,14 @@ mod tests {
             println!("Stats:\n{:#?}", stats);
             assert!(stats.echo_return_loss.has_value);
             assert!(stats.echo_return_loss_enhancement.has_value);
-            assert!(stats.residual_echo_likelihood.has_value);
-            assert!(stats.residual_echo_likelihood_recent_max.has_value);
             assert!(stats.delay_ms.has_value);
+
+            // Residual echo metrics require the bundled internal header.
+            #[cfg(feature = "bundled")]
+            {
+                assert!(stats.residual_echo_likelihood.has_value);
+                assert!(stats.residual_echo_likelihood_recent_max.has_value);
+            }
 
             // Fields declared in upstream but never populated in v2.1.
             // See: webrtc/api/audio/audio_processing_statistics.h

--- a/webrtc-audio-processing-sys/src/lib.rs
+++ b/webrtc-audio-processing-sys/src/lib.rs
@@ -150,7 +150,7 @@ mod tests {
 
             let stream_config = create_stream_config(SAMPLE_RATE_HZ, 1);
             let num_samples = stream_config.num_frames_; // frames in WebRTC == our samples
-            let mut frame = vec![vec![0f32; num_samples as usize]; 1];
+            let mut frame = vec![vec![0f32; num_samples]; 1];
             let frame_ptr = frame.iter_mut().map(|v| v.as_mut_ptr()).collect::<Vec<*mut f32>>();
             assert_success(process_render_frame(ap, &stream_config, frame_ptr.as_ptr()));
             assert_success(process_capture_frame(ap, &stream_config, frame_ptr.as_ptr()));
@@ -196,7 +196,7 @@ mod tests {
 
             let stream_config = create_stream_config(SAMPLE_RATE_HZ, 1);
             let num_samples = stream_config.num_frames_; // frames in WebRTC == our samples
-            let mut frame = vec![vec![0f32; num_samples as usize]; 1];
+            let mut frame = vec![vec![0f32; num_samples]; 1];
             let frame_ptr = frame.iter_mut().map(|v| v.as_mut_ptr()).collect::<Vec<*mut f32>>();
             assert_success(process_render_frame(ap, &stream_config, frame_ptr.as_ptr()));
             assert_success(process_capture_frame(ap, &stream_config, frame_ptr.as_ptr()));

--- a/webrtc-audio-processing-sys/src/lib.rs
+++ b/webrtc-audio-processing-sys/src/lib.rs
@@ -213,6 +213,12 @@ mod tests {
                 assert!(stats.residual_echo_likelihood.has_value);
                 assert!(stats.residual_echo_likelihood_recent_max.has_value);
             }
+            #[cfg(not(feature = "bundled"))]
+            {
+                // Residual echo metrics are always None when echo detector is not bundled.
+                assert!(!stats.residual_echo_likelihood.has_value);
+                assert!(!stats.residual_echo_likelihood_recent_max.has_value);
+            }
 
             // Fields declared in upstream but never populated in v2.1.
             // See: webrtc/api/audio/audio_processing_statistics.h

--- a/webrtc-audio-processing-sys/src/wrapper.cpp
+++ b/webrtc-audio-processing-sys/src/wrapper.cpp
@@ -8,8 +8,10 @@
 #ifdef WEBRTC_AEC3_CONFIG
 #include "modules/audio_processing/aec3/echo_canceller3.h"
 #endif
+#ifdef WEBRTC_HAS_INTERNAL_HEADERS
 #include "modules/audio_processing/residual_echo_detector.h"
 #include "rtc_base/ref_counted_object.h"
+#endif
 
 #include <algorithm>
 #include <memory>
@@ -98,9 +100,11 @@ AudioProcessing* create_audio_processing(
 #endif
   }
 
-  // Set the echo detector to provide echo metrics.
+  // Set the echo detector to provide echo metrics when bundled.
+#ifdef WEBRTC_HAS_INTERNAL_HEADERS
   builder.SetEchoDetector(rtc::scoped_refptr<webrtc::EchoDetector>(
       new rtc::RefCountedObject<webrtc::ResidualEchoDetector>()));
+#endif
   ap->processor.reset(builder.Create().release());
 
   return ap.release();

--- a/webrtc-audio-processing-sys/src/wrapper.cpp
+++ b/webrtc-audio-processing-sys/src/wrapper.cpp
@@ -8,6 +8,8 @@
 #ifdef WEBRTC_AEC3_CONFIG
 #include "modules/audio_processing/aec3/echo_canceller3.h"
 #endif
+#include "modules/audio_processing/residual_echo_detector.h"
+#include "rtc_base/ref_counted_object.h"
 
 #include <algorithm>
 #include <memory>
@@ -95,6 +97,10 @@ AudioProcessing* create_audio_processing(
     return nullptr;
 #endif
   }
+
+  // Set the echo detector to provide echo metrics.
+  builder.SetEchoDetector(rtc::scoped_refptr<webrtc::EchoDetector>(
+      new rtc::RefCountedObject<webrtc::ResidualEchoDetector>()));
   ap->processor.reset(builder.Create().release());
 
   return ap.release();


### PR DESCRIPTION
There are currently some metrics that are unpopulated upstream (`voice_detected`, `delay_median_ms`, `delay_standard_deviation_ms`, `divergent_filter_fraction`). We were curious about this before but it's clear on investigation they are actually unpopulated. 

The residual echo metrics also needed to have its echo detector enabled otherwise they were never populated.

```cpp
// webrtc/modules/audio_processing/audio_processing_impl.cc:1470-1476
if (submodules_.echo_detector) {
    auto ed_metrics = submodules_.echo_detector->GetMetrics();
    capture_.stats.residual_echo_likelihood = ed_metrics.echo_likelihood;
}
```

Which requires us to `SetEchoDetector`.

Currently doesn't work with non-bundled variants.