### PR TITLE
build(sys): generate meson cross-file when target arch != host on macOS

### DIFF
--- a/webrtc-audio-processing-sys/build.rs
+++ b/webrtc-audio-processing-sys/build.rs
@@ -212,6 +212,16 @@ mod webrtc {
         meson.arg("setup").arg("--prefix").arg(out_dir().as_os_str());
         meson.arg("--reconfigure");
 
+        // When cross-compiling between Apple Silicon and Intel macOS, meson
+        // otherwise builds for the build machine's arch (because nothing tells
+        // it the target is different) and the resulting objects fail the final
+        // link with "found architecture 'arm64', required architecture 'x86_64'"
+        // (or vice versa). Pass an explicit cross-file in that case.
+        let cross_file = write_macos_cross_file_if_needed()?;
+        if let Some(ref path) = cross_file {
+            meson.arg("--cross-file").arg(path);
+        }
+
         if cfg!(target_os = "macos") {
             let link_args = "['-framework', 'CoreFoundation', '-framework', 'Foundation']";
             meson.arg(format!("-Dc_link_args={}", link_args));
@@ -485,4 +495,42 @@ fn determine_objcopy_path() -> Result<PathBuf> {
     }
 
     Ok(objcopy)
+}
+
+/// Write a meson cross-file to OUT_DIR when cross-compiling between Apple Silicon
+/// and Intel macOS, and return its path. Returns None when no cross-file is
+/// needed (target == host, or non-darwin target). Without this, meson defaults
+/// to the build machine's arch and the resulting objects are rejected by the
+/// linker for the actual target arch — the failure mode that breaks
+/// `cargo build --target universal-apple-darwin` on an arm64 build host.
+fn write_macos_cross_file_if_needed() -> Result<Option<PathBuf>> {
+    let target = env::var("TARGET").unwrap_or_default();
+    let host = env::var("HOST").unwrap_or_default();
+    if target == host {
+        return Ok(None);
+    }
+    let (arch, cpu_family) = match target.as_str() {
+        "x86_64-apple-darwin" => ("x86_64", "x86_64"),
+        "aarch64-apple-darwin" => ("arm64", "aarch64"),
+        // Any other cross-target (e.g. arm64 → linux) is out of scope here;
+        // those paths weren't broken to begin with.
+        _ => return Ok(None),
+    };
+    let cross_file = out_dir().join(format!("meson-cross-{arch}.ini"));
+    let content = format!(
+        "[binaries]\n\
+         c = ['clang', '-arch', '{arch}']\n\
+         cpp = ['clang++', '-arch', '{arch}']\n\
+         ar = 'ar'\n\
+         strip = 'strip'\n\
+         \n\
+         [host_machine]\n\
+         system = 'darwin'\n\
+         cpu_family = '{cpu_family}'\n\
+         cpu = '{arch}'\n\
+         endian = 'little'\n",
+    );
+    std::fs::write(&cross_file, content)
+        .with_context(|| format!("Failed to write meson cross-file at {:?}", cross_file))?;
+    Ok(Some(cross_file))
 }


### PR DESCRIPTION
## Problem

`cargo build --target universal-apple-darwin` (and any other macOS cross-compile pair, e.g. arm64 host targeting x86_64 or vice versa) fails to link against this crate. The bundled C++ webrtc-audio-processing library is compiled for the build machine's arch instead of the requested `TARGET`, so the final link rejects the resulting `.o` files with messages like:

```
ld: warning: ignoring file '…/libwebrtc_audio_processing_sys-….rlib(…)':
    found architecture 'arm64', required architecture 'x86_64'
Undefined symbols for architecture x86_64:
  "v2___ZN6webrtc20EchoCanceller3Config8ValidateEPS0_", …
```

Now that GitHub-hosted Intel macOS runners are gone (only `macos-latest` = arm64 remains), this is the only practical way for projects depending on this crate to ship Intel-compatible macOS binaries. We hit it shipping a Tauri app, where one of our users is on an Intel Mac running macOS Tahoe.

## Root cause

`build.rs` invokes `meson setup` without an explicit cross-file (or any other mechanism to inform meson of the target). Meson defaults to "host machine" = build machine, so it picks up the build machine's arch from its detection and produces `.o` files for that arch regardless of what cargo's `TARGET` says.

## Fix

A small `write_macos_cross_file_if_needed()` helper that:

1. Reads `TARGET` and `HOST` env vars (cargo always sets these for build scripts).
2. Returns `None` when they match (no-op for native builds).
3. Returns `None` when the target isn't `{x86_64,aarch64}-apple-darwin` (other cross-compile paths are out of scope here).
4. Otherwise writes a meson `.ini` cross-file to `OUT_DIR` with the appropriate `-arch` flag on `clang`/`clang++` and a matching `[host_machine]` section, and returns its path.

The existing meson invocation gets one new line: `if let Some(ref path) = cross_file { meson.arg("--cross-file").arg(path); }`.

Total diff: **+48 lines, 1 file** (`webrtc-audio-processing-sys/build.rs`).

## Verification

Tested on an arm64 macOS host (macos-latest equivalent):

- `cargo build --target x86_64-apple-darwin` — compiles cleanly, ~1m16s.
- `cargo build --target aarch64-apple-darwin --target x86_64-apple-darwin` (the underlying invocation for Tauri's `universal-apple-darwin`) — ~59s wall-clock with both slices in parallel.
- `cargo build --target aarch64-apple-darwin` on the same host — unchanged (no cross-file written, identical behavior to before).

## Scope kept narrow

- No changes to bindings, the cc-built wrapper, symbol prefixing, the bundled webrtc source, or anything else.
- Cross-file is only written for the `{x86_64,aarch64}-apple-darwin` ↔ `{aarch64,x86_64}-apple-darwin` cases — any other cross target path (Linux → macOS via osxcross, etc.) is unaffected and falls through to the existing behavior.
- Backward-compatible: native builds on either arch produce identical output to before.

Happy to expand to cover other targets if useful (e.g. ios), or split into smaller commits if you'd prefer that shape.
